### PR TITLE
Update a major tag to point to the latest release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,17 @@
+name: Publish
+
+on:
+  release:
+    types:
+      - published
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/publish-action@v0.4.0
+        with:
+          source-tag: ${{ github.ref_name }}


### PR DESCRIPTION
Currently, v1 is pointing to v1.2.0 instead of the latest v1.3.1.
Whoever following the readme and `uses: roots/setup-trellis-cli@v1` would get the outdated v1.2.0.

This PR introduces a new workflow to automatically update a major tag (e.g: v1) to point to the latest release upon release published.

Note: Ideally, we would use `publish-immutable-action` instead but [it isn't publicly available yet](https://github.com/actions/publish-immutable-action/issues/226).